### PR TITLE
[🐸 Frogbot] Update NuGet dependencies

### DIFF
--- a/nuget1.csproj
+++ b/nuget1.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="snappier" Version="1.1.0" />
-    <PackageReference Include="ssh.net" Version="2020.0.0" />
+    <PackageReference Include="snappier" Version="1.1.1" />
+    <PackageReference Include="ssh.net" Version="2020.0.2" />
   </ItemGroup>
 
 </Project>

--- a/obj/nuget1.csproj.nuget.dgspec.json
+++ b/obj/nuget1.csproj.nuget.dgspec.json
@@ -1,17 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj": {}
+    "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj": {}
   },
   "projects": {
-    "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj": {
+    "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj": {
       "version": "1.0.0",
       "restore": {
-        "projectUniqueName": "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj",
+        "projectUniqueName": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj",
         "projectName": "nuget1",
-        "projectPath": "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj",
+        "projectPath": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj",
         "packagesPath": "/Users/erant/.nuget/packages/",
-        "outputPath": "/Users/erant/Desktop/my-project-examples/nuget1/obj/",
+        "outputPath": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/obj/",
         "projectStyle": "PackageReference",
         "configFilePaths": [
           "/Users/erant/.nuget/NuGet/NuGet.Config"
@@ -38,14 +38,14 @@
           "dependencies": {
             "snappier": {
               "target": "Package",
-              "version": "[1.1.0, )"
+              "version": "[1.1.1, )"
             },
             "ssh.net": {
               "target": "Package",
-              "version": "[2020.0.0, )"
+              "version": "[2020.0.2, )"
             }
           },
-          "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/sdk/3.1.426/RuntimeIdentifierGraph.json"
+          "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/x64/sdk/3.1.426/RuntimeIdentifierGraph.json"
         }
       }
     }

--- a/obj/project.assets.json
+++ b/obj/project.assets.json
@@ -2,7 +2,7 @@
   "version": 3,
   "targets": {
     ".NETCoreApp,Version=v7.0": {
-      "Snappier/1.1.0": {
+      "Snappier/1.1.1": {
         "type": "package",
         "compile": {
           "lib/net7.0/Snappier.dll": {}
@@ -11,7 +11,7 @@
           "lib/net7.0/Snappier.dll": {}
         }
       },
-      "SSH.NET/2020.0.0": {
+      "SSH.NET/2020.0.2": {
         "type": "package",
         "dependencies": {
           "SshNet.Security.Cryptography": "[1.3.0]"
@@ -35,10 +35,10 @@
     }
   },
   "libraries": {
-    "Snappier/1.1.0": {
-      "sha512": "ws78FoXdwY5rTwoSqpdl9HFpgSU4ih0byThG2+s+Bm1VSfyhkQxOdrV0aWQ1R1MptA8EwAcrnn3Mh0GkFSssxA==",
+    "Snappier/1.1.1": {
+      "sha512": "p0xEWUG8wYUfO24b6VTcFplBO+1ohgL9rK+1ogP8N4oGOKXlLuOLpzYtPBXNxTcYQxxmX3PJdCdqnv0tgcy5YQ==",
       "type": "package",
-      "path": "snappier/1.1.0",
+      "path": "snappier/1.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -49,14 +49,14 @@
         "lib/net7.0/Snappier.xml",
         "lib/netstandard2.0/Snappier.dll",
         "lib/netstandard2.0/Snappier.xml",
-        "snappier.1.1.0.nupkg.sha512",
+        "snappier.1.1.1.nupkg.sha512",
         "snappier.nuspec"
       ]
     },
-    "SSH.NET/2020.0.0": {
-      "sha512": "lEO6dMG/FooezubgOHvFq54zmKqtnbDUUU2unnHVyu0p2oRf6Xu5khbqo2lbwv30rJNzAtrCCp2UPAerNbMsbQ==",
+    "SSH.NET/2020.0.2": {
+      "sha512": "G0dNlTBAM00KZXv1wWVwgg26d9/METcM6qWBpNQwllzQmmbu+Zu+FS1L1X4fFgGdPu3e8k9mmTBu6SwtQ0614g==",
       "type": "package",
-      "path": "ssh.net/2020.0.0",
+      "path": "ssh.net/2020.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -78,7 +78,7 @@
         "lib/wp71/Renci.SshNet.xml",
         "lib/wp8/Renci.SshNet.dll",
         "lib/wp8/Renci.SshNet.xml",
-        "ssh.net.2020.0.0.nupkg.sha512",
+        "ssh.net.2020.0.2.nupkg.sha512",
         "ssh.net.nuspec"
       ]
     },
@@ -120,8 +120,8 @@
   },
   "projectFileDependencyGroups": {
     ".NETCoreApp,Version=v7.0": [
-      "snappier >= 1.1.0",
-      "ssh.net >= 2020.0.0"
+      "snappier >= 1.1.1",
+      "ssh.net >= 2020.0.2"
     ]
   },
   "packageFolders": {
@@ -130,11 +130,11 @@
   "project": {
     "version": "1.0.0",
     "restore": {
-      "projectUniqueName": "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj",
+      "projectUniqueName": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj",
       "projectName": "nuget1",
-      "projectPath": "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj",
+      "projectPath": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj",
       "packagesPath": "/Users/erant/.nuget/packages/",
-      "outputPath": "/Users/erant/Desktop/my-project-examples/nuget1/obj/",
+      "outputPath": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/obj/",
       "projectStyle": "PackageReference",
       "configFilePaths": [
         "/Users/erant/.nuget/NuGet/NuGet.Config"
@@ -161,14 +161,14 @@
         "dependencies": {
           "snappier": {
             "target": "Package",
-            "version": "[1.1.0, )"
+            "version": "[1.1.1, )"
           },
           "ssh.net": {
             "target": "Package",
-            "version": "[2020.0.0, )"
+            "version": "[2020.0.2, )"
           }
         },
-        "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/sdk/3.1.426/RuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "/usr/local/share/dotnet/x64/sdk/3.1.426/RuntimeIdentifierGraph.json"
       }
     }
   }

--- a/obj/project.nuget.cache
+++ b/obj/project.nuget.cache
@@ -1,11 +1,11 @@
 {
   "version": 2,
-  "dgSpecHash": "iaQ2X+AO5XU6LUpPGQHlwokWsxe0usWYz6Bi4RFWZb5a7zGmA0dBcXu/69A5EFlzrEi8aqmX5nBcjd/XEVU0TA==",
+  "dgSpecHash": "K5ZgOgLsusIGYEgRzcBV0Orns+UGlGK40ESu/To64Q6kPO0DK3UgD3e7rkA9VkevhBwE2tbqMmb5lP8tYrRnQw==",
   "success": true,
-  "projectFilePath": "/Users/erant/Desktop/my-project-examples/nuget1/nuget1.csproj",
+  "projectFilePath": "/private/var/folders/rn/2q4729rn08qgqr8yj55ny8qh0000gq/T/jfrog.cli.temp.-1693309494-3423645626/nuget1.csproj",
   "expectedPackageFiles": [
-    "/Users/erant/.nuget/packages/snappier/1.1.0/snappier.1.1.0.nupkg.sha512",
-    "/Users/erant/.nuget/packages/ssh.net/2020.0.0/ssh.net.2020.0.0.nupkg.sha512",
+    "/Users/erant/.nuget/packages/snappier/1.1.1/snappier.1.1.1.nupkg.sha512",
+    "/Users/erant/.nuget/packages/ssh.net/2020.0.2/ssh.net.2020.0.2.nupkg.sha512",
     "/Users/erant/.nuget/packages/sshnet.security.cryptography/1.3.0/sshnet.security.cryptography.1.3.0.nupkg.sha512"
   ],
   "logs": []


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">


| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | SSH.NET:2020.0.0 | SSH.NET:2020.0.0 | [2020.0.2] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Snappier:1.1.0 | Snappier:1.1.0 | [1.1.1] |

</div>

## 👇 Details


<details>
<summary> <b>SSH.NET 2020.0.0</b> </summary>
<br>

- **Severity** 🎃 Medium
- **Package Name:** SSH.NET
- **Current Version:** 2020.0.0
- **Fixed Version:** [2020.0.2]
- **CVE:** CVE-2022-29245

**Description:**

SSH.NET is a Secure Shell (SSH) library for .NET. In versions 2020.0.0 and 2020.0.1, during an `X25519` key exchange, the client�??s private key is generated with `System.Random`. `System.Random` is not a cryptographically secure random number generator, it must therefore not be used for cryptographic purposes. When establishing an SSH connection to a remote host, during the X25519 key exchange, the private key is generated with a weak random number generator whose seed can be brute forced. This allows an attacker who is able to eavesdrop on the communications to decrypt them. Version 2020.0.2 contains a patch for this issue. As a workaround, one may disable support for `curve25519-sha256` and `curve25519-sha256@libssh.org` key exchange algorithms.



</details>


<details>
<summary> <b>Snappier 1.1.0</b> </summary>
<br>

- **Severity** 🎃 Medium
- **Package Name:** Snappier
- **Current Version:** 1.1.0
- **Fixed Version:** [1.1.1]
- **CVE:** CVE-2023-28638

**Description:**

Snappier is a high performance C# implementation of the Snappy compression algorithm. This is a buffer overrun vulnerability that can affect any user of Snappier 1.1.0. In this release, much of the code was rewritten to use byte references rather than pointers to pinned buffers. This change generally improves performance and reduces workload on the garbage collector. However, when the garbage collector performs compaction and rearranges memory, it must update any byte references on the stack to refer to the updated location. The .NET garbage collector can only update these byte references if they still point within the buffer or to a point one byte past the end of the buffer. If they point outside this area, the buffer itself may be moved while the byte reference stays the same. There are several places in 1.1.0 where byte references very briefly point outside the valid areas of buffers. These are at locations in the code being used for buffer range checks. While the invalid references are never dereferenced directly, if a GC compaction were to occur during the brief window when they are on the stack then it could invalidate the buffer range check and allow other operations to overrun the buffer. This should be very difficult for an attacker to trigger intentionally. It would require a repetitive bulk attack with the hope that a GC compaction would occur at precisely the right moment during one of the requests. However, one of the range checks with this problem is a check based on input data in the decompression buffer, meaning malformed input data could be used to increase the chance of success. Note that any resulting buffer overrun is likely to cause access to protected memory, which will then cause an exception and the process to be terminated. Therefore, the most likely result of an attack is a denial of service. This issue has been patched in release 1.1.1. Users are advised to upgrade. Users unable to upgrade may pin buffers to a fixed location before using them for compression or decompression to mitigat



</details>


---

<div align="center">

[JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: 4289fc20f0242d3eae338a183956ce9a)
