### PR TITLE
[🐸 Frogbot] Update NuGet dependencies

### DIFF
--- a/nuget1.csproj
+++ b/nuget1.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
-    <PackageReference Include="snappier" Version="1.1.0" />
-    <PackageReference Include="ssh.net" Version="2020.0.0" />
+    <PackageReference Include="snappier" Version="1.1.1" />
+    <PackageReference Include="ssh.net" Version="2020.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies

### ✍️ Summary

<div align="center">


| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |
| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Snappier:1.1.0 | Snappier:1.1.0 | [1.1.1] | CVE-2023-28638 |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | SSH.NET:2020.0.0 | SSH.NET:2020.0.0 | [2020.0.2] | CVE-2022-29245 |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableUnknownSeverity.png)<br> Unknown | Newtonsoft.Json:12.0.3 | Newtonsoft.Json:12.0.3 | [13.0.1] |  -  |

</div>

## 🔬 Research Details

<details>
<summary> <b>[ CVE-2023-28638 ] Snappier 1.1.0</b> </summary>
<br>

**Description:**
Snappier is a high performance C# implementation of the Snappy compression algorithm. This is a buffer overrun vulnerability that can affect any user of Snappier 1.1.0. In this release, much of the code was rewritten to use byte references rather than pointers to pinned buffers. This change generally improves performance and reduces workload on the garbage collector. However, when the garbage collector performs compaction and rearranges memory, it must update any byte references on the stack to refer to the updated location. The .NET garbage collector can only update these byte references if they still point within the buffer or to a point one byte past the end of the buffer. If they point outside this area, the buffer itself may be moved while the byte reference stays the same. There are several places in 1.1.0 where byte references very briefly point outside the valid areas of buffers. These are at locations in the code being used for buffer range checks. While the invalid references are never dereferenced directly, if a GC compaction were to occur during the brief window when they are on the stack then it could invalidate the buffer range check and allow other operations to overrun the buffer. This should be very difficult for an attacker to trigger intentionally. It would require a repetitive bulk attack with the hope that a GC compaction would occur at precisely the right moment during one of the requests. However, one of the range checks with this problem is a check based on input data in the decompression buffer, meaning malformed input data could be used to increase the chance of success. Note that any resulting buffer overrun is likely to cause access to protected memory, which will then cause an exception and the process to be terminated. Therefore, the most likely result of an attack is a denial of service. This issue has been patched in release 1.1.1. Users are advised to upgrade. Users unable to upgrade may pin buffers to a fixed location before using them for compression or decompression to mitigat


</details>


<details>
<summary> <b>[ CVE-2022-29245 ] SSH.NET 2020.0.0</b> </summary>
<br>

**Description:**
SSH.NET is a Secure Shell (SSH) library for .NET. In versions 2020.0.0 and 2020.0.1, during an `X25519` key exchange, the client�??s private key is generated with `System.Random`. `System.Random` is not a cryptographically secure random number generator, it must therefore not be used for cryptographic purposes. When establishing an SSH connection to a remote host, during the X25519 key exchange, the private key is generated with a weak random number generator whose seed can be brute forced. This allows an attacker who is able to eavesdrop on the communications to decrypt them. Version 2020.0.2 contains a patch for this issue. As a workaround, one may disable support for `curve25519-sha256` and `curve25519-sha256@libssh.org` key exchange algorithms.


</details>


<details>
<summary> <b>[ XRAY-138885 ] Newtonsoft.Json 12.0.3</b> </summary>
<br>

**Description:**
Newtonsoft Json.NET (Newtonsoft.Json) JSON Deserialization Nested Object Recursion Handling Stack Exhaustion DoS Weakness


</details>


---
<div align="center">

[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: ec0b1e8647db74e8b144845ade6c8e46)
